### PR TITLE
Setting app info for user agent

### DIFF
--- a/stripe/config.go
+++ b/stripe/config.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"github.com/stripe/stripe-go"
 	"log"
 
 	"github.com/stripe/stripe-go/client"
@@ -13,6 +14,10 @@ type Config struct {
 
 // Client returns a new Client for accessing Stripe.
 func (c *Config) Client() (*client.API, error) {
+	stripe.SetAppInfo(&stripe.AppInfo{
+		Name: "terraform-provider-stripe",
+	})
+
 	client := &client.API{}
 	client.Init(c.APIToken, nil)
 	log.Printf("[INFO] Stripe Client configured.")


### PR DESCRIPTION
This plugin now identifies itself when communicating with Stripe, according to https://github.com/stripe/stripe-go/#writing-a-plugin.