### PR TITLE
Add webhook secret as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ resource "stripe_webhook_endpoint" "my_endpoint" {
 - [x] Webhook endpoints
   - url
   - enabled_events
+  - secret (computed variable, set on creation)
 
 
 ## Developing the Provider

--- a/main.tf
+++ b/main.tf
@@ -25,3 +25,7 @@ resource "stripe_webhook_endpoint" "my_endpoint" {
     "source.chargeable",
   ]
 }
+
+output "webhook_secret" {
+  value = "${stripe_webhook_endpoint.my_endpoint.secret}"
+}

--- a/stripe/resource_stripe_webhook_endpoint.go
+++ b/stripe/resource_stripe_webhook_endpoint.go
@@ -28,6 +28,10 @@ func resourceStripeWebhookEndpoint() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
 			},
+			"secret": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -52,6 +56,7 @@ func resourceStripeWebhookEndpointCreate(d *schema.ResourceData, m interface{}) 
 	if err == nil {
 		log.Printf("[INFO] Create wehbook endpoint: %s", webhookEndpointURL)
 		d.SetId(webhookEndpoint.ID)
+		d.Set("secret", webhookEndpoint.Secret)
 	}
 
 	return err


### PR DESCRIPTION
Allows to access the webhook secret that is generated when a webhook endpoint is created:

```terraform
resource "stripe_webhook_endpoint" "my_endpoint" {
  url = "https://mydomain.example.com/webhook"

  enabled_events = [
    "charge.succeeded",
    "charge.failed",
    "source.chargeable",
  ]
}

output "webhook_secret" {
  value = "${stripe_webhook_endpoint.my_endpoint.secret}"
}
```