### PR TITLE
Fix package import and readme; add make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ default: build
 
 .PHONY=build
 build:
+	go get ./...
 	go build -o terraform-provider-stripe
 
 test: build
@@ -9,6 +10,11 @@ test: build
 	terraform fmt
 	terraform plan -out terraform.tfplan
 	terraform apply terraform.tfplan
+
+.PHONY=install
+install: build
+	mkdir -p ~/.terraform.d/plugins
+	cp ./terraform-provider-stripe ~/.terraform.d/plugins/
 
 .PHONY: authors
 authors:

--- a/README.md
+++ b/README.md
@@ -16,18 +16,25 @@ endpoints—via Terraform.
 
 ## Building The Provider
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-stripe`
+Clone repository to: `$GOPATH/src/github.com/franckverrot/terraform-provider-stripe`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-stripe
+$ mkdir -p $GOPATH/src/github.com/franckverrot; cd $GOPATH/src/github.com/franckverrot
+$ git clone git@github.com:franckverrot/terraform-provider-stripe
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-stripe
+$ cd $GOPATH/src/github.com/franckverrot/terraform-provider-stripe
 $ make build
+```
+
+Or alternatively, to install it as a plugin, run
+
+```sh
+$ cd $GOPATH/src/github.com/franckverrot/terraform-provider-stripe
+$ make install
 ```
 
 ## Using the provider

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/franckverrot/terraform-provider-stripe/stripe"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-stripe/stripe"
 )
 
 func main() {


### PR DESCRIPTION
Looks like this repo hasn't been moved to `terraform-providers`, so I was having trouble compiling it. Also made sure to install the dependencies in `make build` and added a `make install` to place the binary where needed on *nix systems.

![](https://cl.ly/aa9b2fc1c7cb/Image%202019-03-07%20at%203.35.24%20PM.png)