### PR TITLE
Add plan_id to the plan resource

### DIFF
--- a/stripe/resource_stripe_plan.go
+++ b/stripe/resource_stripe_plan.go
@@ -19,6 +19,10 @@ func resourceStripePlan() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"plan_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"active": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -105,6 +109,10 @@ func resourceStripePlanCreate(d *schema.ResourceData, m interface{}) error {
 		Currency:  stripe.String(planCurrency),
 	}
 
+	if id, ok := d.GetOk("plan_id"); ok {
+		params.ID = stripe.String(id.(string))
+	}
+
 	if active, ok := d.GetOk("active"); ok {
 		params.Active = stripe.Bool(active.(bool))
 	}
@@ -160,6 +168,7 @@ func resourceStripePlanRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		d.SetId("")
 	} else {
+		d.Set("plan_id", plan.ID)
 		d.Set("active", plan.Active)
 		d.Set("aggregate_usage", plan.AggregateUsage)
 		d.Set("amount", plan.Amount)
@@ -181,6 +190,10 @@ func resourceStripePlanRead(d *schema.ResourceData, m interface{}) error {
 func resourceStripePlanUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*client.API)
 	params := stripe.PlanParams{}
+
+	if d.HasChange("plan_id") {
+		params.ID = stripe.String(d.Get("plan_id").(string))
+	}
 
 	if d.HasChange("active") {
 		params.Active = stripe.Bool(bool(d.Get("active").(bool)))


### PR DESCRIPTION
Stripe gives you the ability to set a custom plan_id.  This can be useful if you want your development and production environments to mirror eachother.  This way I can ensure the code I tested in development will not fail due to incorrect plan ids in production (since they are the same).

In terraform 12.x the `id` field is reserved. I looked at other providers to see how they handle this, and they seem to use the convention where they prefix the attribute with the resource name. I therefore used `plan_id` instead of `id`.

I have tested these changes in live and production mode in Stripe and they work as expected :)