### PR TITLE
Add tiers to plan resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ resource "stripe_coupon" "mlk_day_coupon_25pc_off" {
   - [x] metadata (map)
   - [x] nickname
   - [x] product
-  - [ ] tiers
+  - [x] tiers
   - [x] tiers mode
   - [ ] transform_usage
   - [x] trial period days

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,32 @@ resource "stripe_plan" "my_product_plan" {
   currency = "usd"
 }
 
+resource "stripe_plan" "my_product_metered_plan" {
+  product  = "${stripe_product.my_product.id}"
+  interval = "month"
+  currency = "usd"
+
+  usage_type      = "metered"
+  billing_scheme  = "tiered"
+  tiers_mode      = "graduated"
+  aggregate_usage = "max"
+
+  tier {
+    up_to       = 5
+    unit_amount = 50
+  }
+
+  tier {
+    up_to       = 15
+    unit_amount = 35
+  }
+
+  tier {
+    up_to_inf   = true
+    unit_amount = 25
+  }
+}
+
 resource "stripe_webhook_endpoint" "my_endpoint" {
   url = "https://mydomain.example.com/webhook"
 

--- a/stripe/resource_stripe_plan.go
+++ b/stripe/resource_stripe_plan.go
@@ -46,15 +46,18 @@ func resourceStripePlan() *schema.Resource {
 			"aggregate_usage": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"billing_scheme": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  "per_unit",
 			},
 			"interval_count": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
+				ForceNew: true,
 				Default:  1,
 			},
 			"metadata": &schema.Schema{
@@ -72,6 +75,7 @@ func resourceStripePlan() *schema.Resource {
 			"tiers_mode": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			// TODO: transform_usage
 			"trial_period_days": &schema.Schema{
@@ -81,6 +85,7 @@ func resourceStripePlan() *schema.Resource {
 			"usage_type": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  "licensed",
 			},
 		},
@@ -186,18 +191,6 @@ func resourceStripePlanUpdate(d *schema.ResourceData, m interface{}) error {
 		params.Active = stripe.Bool(bool(d.Get("active").(bool)))
 	}
 
-	if d.HasChange("aggregate_usage") {
-		params.AggregateUsage = stripe.String(d.Get("aggregate_usage").(string))
-	}
-
-	if d.HasChange("billing_scheme") {
-		params.BillingScheme = stripe.String(d.Get("billing_scheme").(string))
-	}
-
-	if d.HasChange("interval_count") {
-		params.IntervalCount = stripe.Int64(int64(d.Get("interval_count").(int)))
-	}
-
 	if d.HasChange("metadata") {
 		params.Metadata = expandMetadata(d)
 	}
@@ -206,16 +199,8 @@ func resourceStripePlanUpdate(d *schema.ResourceData, m interface{}) error {
 		params.Nickname = stripe.String(d.Get("nickname").(string))
 	}
 
-	if d.HasChange("tiers_mode") {
-		params.TiersMode = stripe.String(d.Get("tiers_mode").(string))
-	}
-
 	if d.HasChange("trial_period_days") {
 		params.TrialPeriodDays = stripe.Int64(int64(d.Get("trial_period_days").(int)))
-	}
-
-	if d.HasChange("usage_type") {
-		params.UsageType = stripe.String(d.Get("usage_type").(string))
 	}
 
 	_, err := client.Plans.Update(d.Id(), &params)


### PR DESCRIPTION
This PR adds [tiers](https://stripe.com/docs/billing/subscriptions/tiers) to the plan resource.

```hcl
resource "stripe_plan" "some_plan" {
  ...

  tier {
    up_to       = 20
    unit_amount = 0
  }

  tier {
    up_to       = 100
    unit_amount = 350
  }

  tier {
    up_to_inf   = true
    unit_amount = 250
  }
}
```

It's a `ForceNew` field, because Stripe's [plan update endpoint](https://stripe.com/docs/api/plans/update) doesn't support it.