### PR TITLE
Fix importing

### DIFF
--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -189,7 +189,11 @@ func resourceStripeCouponRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("metadata", coupon.Metadata)
 		d.Set("name", coupon.Name)
 		d.Set("percent_off", coupon.PercentOff)
-		d.Set("redeem_by", time.Unix(coupon.RedeemBy, 0).UTC().Format(time.RFC3339))
+
+		if coupon.RedeemBy > 0 {
+			d.Set("redeem_by", time.Unix(coupon.RedeemBy, 0).UTC().Format(time.RFC3339))
+		}
+
 		d.Set("times_redeemed", coupon.TimesRedeemed)
 		d.Set("valid", coupon.Valid)
 		d.Set("created", coupon.Valid)

--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -179,6 +179,7 @@ func resourceStripeCouponRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		d.SetId("")
 	} else {
+		d.Set("code", d.Id())
 		d.Set("amount_off", coupon.AmountOff)
 		d.Set("currency", coupon.Currency)
 		d.Set("duration", coupon.Duration)

--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -188,7 +188,7 @@ func resourceStripeCouponRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("metadata", coupon.Metadata)
 		d.Set("name", coupon.Name)
 		d.Set("percent_off", coupon.PercentOff)
-		d.Set("redeem_by", coupon.RedeemBy)
+		d.Set("redeem_by", time.Unix(coupon.RedeemBy, 0).UTC().Format(time.RFC3339))
 		d.Set("times_redeemed", coupon.TimesRedeemed)
 		d.Set("valid", coupon.Valid)
 		d.Set("created", coupon.Valid)

--- a/stripe/resource_stripe_plan.go
+++ b/stripe/resource_stripe_plan.go
@@ -221,7 +221,7 @@ func resourceStripePlanRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("interval_count", plan.IntervalCount)
 		d.Set("metadata", plan.Metadata)
 		d.Set("nickname", plan.Nickname)
-		d.Set("product", plan.Product)
+		d.Set("product", plan.Product.ID)
 		d.Set("tiers_mode", plan.TiersMode)
 		d.Set("tier", flattenPlanTiers(plan.Tiers))
 		d.Set("trial_period_days", plan.TrialPeriodDays)


### PR DESCRIPTION
Imported plan & coupon has difference

[coupon]
Imported plan has no code and redeem_by.
```
  # stripe_coupon.my_coupon must be replaced
-/+ resource "stripe_coupon" "my_coupon" {
      ...
      + code               = "my_coupon"
      ...
      + redeem_by          = "2000-01-01T00:00:00Z" # forces replacement
      ...
    }
```

[plan]
Imported plan has no product.
```
  # stripe_plan.my_plan will be updated in-place
  ~ resource "stripe_plan" "my_plan" {
      ...
      + product           = "my_product"
      ...
    }
```