### PR TITLE
Adapt connect account handling in webhooks

### DIFF
--- a/stripe/resource_stripe_webhook_endpoint.go
+++ b/stripe/resource_stripe_webhook_endpoint.go
@@ -74,7 +74,7 @@ func resourceStripeWebhookEndpointRead(d *schema.ResourceData, m interface{}) er
 
 	d.Set("url", webhookEndpoint.URL)
 	d.Set("enabled_events", webhookEndpoint.EnabledEvents)
-	d.Set("connect", webhookEndpoint.Connect)
+	d.Set("connect", webhookEndpoint.Application != "")
 
 	return nil
 }

--- a/stripe/resource_stripe_webhook_endpoint.go
+++ b/stripe/resource_stripe_webhook_endpoint.go
@@ -31,6 +31,7 @@ func resourceStripeWebhookEndpoint() *schema.Resource {
 			"connect": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 			"secret": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
According to https://stripe.com/docs/api/webhook_endpoints/ cannot be set or read directly, even though the stripe-go library seems to suggest otherwise.
Trying to update it leads to the following error: 
Error: {"code":"parameter_unknown","status":400,"message":"Received unknown parameter: connect","param":"connect","request_id":"...","type":"invalid_request_error"}
Therefore I added the ForceNew

As the connect field is not in the response it has been always set to false. It seems reasonable to deduce the current status from the field application.

