### PR TITLE
Add support for decimal pricing and transform_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ resource "stripe_coupon" "mlk_day_coupon_25pc_off" {
   - [x] product
   - [x] tiers
   - [x] tiers mode
-  - [ ] transform_usage
+  - [x] transform_usage
   - [x] trial period days
   - [x] usage type (Default: licensed)
 - [x] [Webhook Endpoints](https://stripe.com/docs/api/webhook_endpoints)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ resource "stripe_coupon" "mlk_day_coupon_25pc_off" {
   - [x] active (Default: true)
   - [x] aggregate usage
   - [x] amount
+  - [x] amount_decimal
   - [x] billing scheme (Default: per_unit)
   - [x] currency
   - [x] interval

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.6
-	github.com/stripe/stripe-go v61.27.0+incompatible
+	github.com/stripe/stripe-go v62.4.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ github.com/stripe/stripe-go v60.12.2+incompatible h1:shsgEOTDDXCFsVXDcLsGFdf5h4U
 github.com/stripe/stripe-go v60.12.2+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stripe/stripe-go v61.27.0+incompatible h1:p0HgsaOYus3VbiUS26GgnZ/wa3ipIFa+NKoX74mVsHA=
 github.com/stripe/stripe-go v61.27.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
+github.com/stripe/stripe-go v62.4.0+incompatible h1:nVsiVYSZvi3bSjAaM9WVrtD/pyKfyo9vDRTdTp9C2yQ=
+github.com/stripe/stripe-go v62.4.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,17 @@ resource "stripe_plan" "my_decimal_product_plan" {
   currency       = "usd"
 }
 
+resource "stripe_plan" "my_transformed_product_plan" {
+  product  = "${stripe_product.my_product.id}"
+  amount   = 2401
+  interval = "month" # day week month year
+  currency = "usd"
+  transform_usage {
+    divide_by = 7
+    round     = "down"
+  }
+}
+
 resource "stripe_webhook_endpoint" "my_endpoint" {
   url = "https://mydomain.example.com/webhook"
 

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,13 @@ resource "stripe_plan" "my_product_plan_with_id" {
   currency = "usd"
 }
 
+resource "stripe_plan" "my_decimal_product_plan" {
+  product        = "${stripe_product.my_product.id}"
+  amount_decimal = 123.45
+  interval       = "month" # day week month year
+  currency       = "usd"
+}
+
 resource "stripe_webhook_endpoint" "my_endpoint" {
   url = "https://mydomain.example.com/webhook"
 

--- a/stripe/resource_stripe_plan.go
+++ b/stripe/resource_stripe_plan.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/client"
 )
@@ -143,9 +144,10 @@ func resourceStripePlan() *schema.Resource {
 							ForceNew: true,
 						},
 						"round": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"down", "up"}, false),
 						},
 					},
 				},


### PR DESCRIPTION
I haven't written Go in years (and never wrote much to begin with), but hopefully this looks good.

I only updated Stripe to the version that added support for decimal pricing, should I instead bump it up to the latest?

edit: ~indenting looks all over the place in the diff despite being fine in my editor, will fix~ fixed

`make test` doesn't pass yet, will update when it does.