### PR TITLE
Add unit_amount_decimal to prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ resource "stripe_coupon" "mlk_day_coupon_25pc_off" {
   - [x] metadata (map)
   - [x] statement descriptor
   - [x] unit label
+- [x] [Prices](https://stripe.com/docs/api/prices)
+  - [x] active (Default: true)
+  - [x] currency
+  - [x] metadata (map)
+  - [x] nickname
+  - [x] product
+  - [x] recurring
+  - [x] unit_amount
+  - [x] billing_scheme
+  - [x] unit_amount_decimal
 - [x] [Plans](https://stripe.com/docs/api/plans)
   - [x] active (Default: true)
   - [x] aggregate usage

--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -63,6 +63,13 @@ func resourceStripePrice() *schema.Resource {
 			},
 			"unit_amount": &schema.Schema{
 				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"unit_amount_decimal": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Computed: true,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -145,6 +152,10 @@ func resourceStripePriceCreate(d *schema.ResourceData, m interface{}) error {
 		params.UnitAmount = stripe.Int64(int64(unitAmount.(int)))
 	}
 
+	if unitAmountDecimal, ok := d.GetOk("unit_amount_decimal"); ok {
+		params.UnitAmountDecimal = stripe.Float64(unitAmountDecimal.(float64))
+	}
+
 	if billingScheme, ok := d.GetOk("billing_scheme"); ok {
 		params.BillingScheme = stripe.String(billingScheme.(string))
 	}
@@ -177,6 +188,7 @@ func resourceStripePriceRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("product", price.Livemode)
 		d.Set("recurring", price.Active)
 		d.Set("unit_amount", price.UnitAmount)
+		d.Set("unit_amount_decimal", price.UnitAmountDecimal)
 		d.Set("billing_scheme", price.BillingScheme)
 	}
 


### PR DESCRIPTION
It's an alternative option for unit_amount: https://stripe.com/docs/api/prices/create

Tested locally and it works. Also updated the README to include prices.

**Note: I don't need a new release for this, I'm building from source anyway :)**