### PR TITLE
Add docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+---
+page_title: "Stripe Provider"
+subcategory: ""
+description: |-
+  
+---
+
+# Stripe Provider
+
+This provider enables Stripe merchants to manage certain parts of their
+Stripe infrastructure—products, plans, webhook endpoints—via Terraform.
+
+Example use cases:
+
+* Create and update resources in a repeatable manner
+* Clone resources across multiple Stripe accounts (e.g. different locales or brands)
+
+Use the navigation to the left to read about the available resources.
+
+## Example usage
+
+```hcl
+provider "stripe" {
+  api_token = "sk_live_..."
+}
+
+resource "stripe_product" "my_product" {
+# ...
+}
+```
+
+### Environment variables
+
+You can provide your API key via `STRIPE_API_TOKEN` environment variable, representing your Stripe API key. When using this method, you may omit the Stripe `provider` block entirely:
+
+```hcl
+resource "stripe_product" "my_product" {
+# ...
+}
+```
+
+Usage:
+
+```bash
+$ export STRIPE_API_TOKEN="sk_live_..."
+$ terraform plan
+```
+
+## Schema
+
+### Optional
+
+- **api_token** (String) – Stripe API key from https://dashboard.stripe.com/apikeys

--- a/docs/resources/coupon.md
+++ b/docs/resources/coupon.md
@@ -1,0 +1,65 @@
+---
+page_title: "stripe_coupon"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_coupon
+
+## Example Usage
+
+```hcl
+resource "stripe_coupon" "mlk_day_coupon_25pc_off" {
+  code     = "MLK_DAY"
+  name     = "King Sales Event"
+  duration = "once"
+
+  amount_off = 4200
+  currency   = "usd" # lowercase
+
+  metadata = {
+    mlk   = "<3"
+    sales = "yes"
+  }
+
+  max_redemptions = 1024
+  redeem_by       = "2019-09-02T12:34:56-08:00" # RFC3339, in the future
+}
+```
+
+## Import
+
+This is an example of the import command being applied to the resource named `stripe_coupon.mlk_day_coupon_25pc_off`. The resource ID is a coupon code.
+
+```bash
+$ terraform import stripe_coupon.mlk_day_coupon_25pc_off MLK_DAY
+```
+
+## Schema
+
+### Required
+
+- **code** (String) The unique identifier of the coupon.
+- **duration** (String) One of `forever`, `once`, and `repeating`. Describes how long a customer who applies this coupon will get the discount.
+
+### Optional
+
+- **amount_off** (Number) Amount (in the `currency` specified) that will be taken off the subtotal of any invoices for this customer.
+- **currency** (String) If `amount_off` has been set, the three-letter ISO code for the currency of the amount to take off.
+- **duration_in_months** (Number) If `duration` is `repeating`, the number of months the coupon applies. Null if coupon `duration` is `forever` or `once`.
+- **id** (String) The ID of this resource.
+- **max_redemptions** (Number) Maximum number of times this coupon can be redeemed, in total, across all customers, before it is no longer valid.
+- **metadata** (Map of String) Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+- **name** (String) Name of the coupon displayed to customers on for instance invoices or receipts.
+- **percent_off** (Number) Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $100 invoice $50 instead.
+- **redeem_by** (String) Date after which the coupon can no longer be redeemed.
+
+### Read-Only
+
+- **created** (Number) Time at which the object was created. Measured in seconds since the Unix epoch.
+- **livemode** (Boolean) Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+- **times_redeemed** (Number) Number of times this coupon has been applied to a customer.
+- **valid** (Boolean) Taking account of the above properties, whether this coupon can still be applied to a customer.
+
+

--- a/docs/resources/plan.md
+++ b/docs/resources/plan.md
@@ -1,0 +1,76 @@
+---
+page_title: "stripe_plan"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_plan
+
+## Example Usage
+
+```hcl
+resource "stripe_plan" "my_product_plan" {
+  product  = "prod_abc"
+  amount   = 12345
+  interval = "month"
+  currency = "usd"
+}
+```
+
+## Import
+
+This is an example of the import command being applied to the resource named `stripe_plan.my_product_plan`. The resource ID is a product ID.
+
+```bash
+$ terraform import stripe_plan.my_product_plan prod_abc
+```
+
+## Schema
+
+### Required
+
+- **currency** (String) Three-letter ISO currency code, in lowercase. Must be a supported currency.
+- **interval** (String) The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
+- **product** (String) The product whose pricing this plan determines.
+
+### Optional
+
+- **active** (Boolean) Whether the plan can be used for new purchases.
+- **aggregate_usage** (String) Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
+- **amount** (Number) The unit amount in cents to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`.
+- **amount_decimal** (Number) The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`.
+- **billing_scheme** (String) Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
+- **id** (String) The ID of this resource.
+- **interval_count** (Number) The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
+- **metadata** (Map of String) Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+- **nickname** (String) A brief description of the plan, hidden from customers.
+- **plan_id** (String) Unique identifier for the plan.
+- **tier** (Block List) (see [below for nested schema](#nestedblock--tier))
+- **tiers_mode** (String) Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.
+- **transform_usage** (Block List, Max: 1) (see [below for nested schema](#nestedblock--transform_usage))
+- **trial_period_days** (Number) Default number of trial days when subscribing a customer to this plan using `trial_from_plan=true`.
+- **usage_type** (String) Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
+
+<a id="nestedblock--tier"></a>
+### Nested Schema for `tier`
+
+Optional:
+
+- **flat_amount** (Number) Price for the entire tier.
+- **flat_amount_decimal** (Number) Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.
+- **unit_amount** (Number) Per unit price for units relevant to the tier.
+- **unit_amount_decimal** (Number) Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
+- **up_to** (Number) Up to and including to this quantity will be contained in the tier.
+- **up_to_inf** (Boolean)
+
+
+<a id="nestedblock--transform_usage"></a>
+### Nested Schema for `transform_usage`
+
+Required:
+
+- **divide_by** (Number) Divide usage by this number.
+- **round** (String) After division, either round the result `up` or `down`.
+
+

--- a/docs/resources/price.md
+++ b/docs/resources/price.md
@@ -1,0 +1,48 @@
+---
+page_title: "stripe_price"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_price
+
+## Schema
+
+### Required
+
+- **currency** (String) Three-letter ISO currency code, in lowercase. Must be a supported currency.
+
+### Optional
+
+- **active** (Boolean) Whether the price can be used for new purchases.
+- **billing_scheme** (String) Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in quantity (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
+- **id** (String) The ID of this resource.
+- **metadata** (Map of String) Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+- **nickname** (String) A brief description of the price, hidden from customers.
+- **price_id** (String) Unique identifier for the price.
+- **product** (String) The ID of the product this price is associated with.
+- **recurring** (Map of String) The recurring components of a price such as `interval` and `usage_type`.
+- **tier** (Block List) (see [below for nested schema](#nestedblock--tier))
+- **tiers_mode** (String) Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.
+- **unit_amount** (Number) The unit amount in cents to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`.
+- **unit_amount_decimal** (Number) The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`.
+
+### Read-Only
+
+- **created** (Number) Time at which the object was created. Measured in seconds since the Unix epoch.
+- **livemode** (Boolean) Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+
+<a id="nestedblock--tier"></a>
+### Nested Schema for `tier`
+
+Optional:
+
+- **flat_amount** (Number) Price for the entire tier.
+- **flat_amount_decimal** (Number) Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.
+- **unit_amount** (Number) Per unit price for units relevant to the tier.
+- **unit_amount_decimal** (Number) Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
+- **up_to** (Number) Up to and including to this quantity will be contained in the tier.
+- **up_to_inf** (Boolean)
+
+

--- a/docs/resources/product.md
+++ b/docs/resources/product.md
@@ -1,0 +1,36 @@
+---
+page_title: "stripe_product"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_product
+
+## Example Usage
+
+```hcl
+resource "stripe_product" "my_product" {
+  name = "My Product"
+  type = "service"
+}
+```
+
+## Schema
+
+### Required
+
+- **name** (String) The product’s name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+- **type** (String)
+
+### Optional
+
+- **active** (Boolean) Whether the product is currently available for purchase. Defaults to `true`.
+- **attributes** (List of String)
+- **id** (String) The ID of this resource.
+- **metadata** (Map of String) Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+- **product_id** (String) Unique identifier for the product.
+- **statement_descriptor** (String) Extra information about a product which will appear on your customer’s credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used.
+- **unit_label** (String) A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions.
+
+

--- a/docs/resources/tax_rate.md
+++ b/docs/resources/tax_rate.md
@@ -1,0 +1,31 @@
+---
+page_title: "stripe_tax_rate"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_tax_rate
+
+## Schema
+
+### Required
+
+- **active** (Boolean) Defaults to `true`. When set to `false`, this tax rate cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
+- **display_name** (String) The display name of the tax rates as it will appear to your customer on their receipt email, PDF, and the hosted invoice page.
+- **inclusive** (Boolean) This specifies if the tax rate is inclusive or exclusive.
+- **percentage** (Number) This represents the tax rate percent out of 100.
+
+### Optional
+
+- **description** (String) An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers.
+- **id** (String) The ID of this resource.
+- **jurisdiction** (String) The jurisdiction for the tax rate. You can use this label field for tax reporting purposes. It also appears on your customer’s invoice.
+- **metadata** (Map of String) Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+
+### Read-Only
+
+- **created** (Number) Time at which the object was created. Measured in seconds since the Unix epoch.
+- **livemode** (Boolean) Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+
+

--- a/docs/resources/webhook_endpoint.md
+++ b/docs/resources/webhook_endpoint.md
@@ -1,0 +1,40 @@
+---
+page_title: "stripe_webhook_endpoint"
+subcategory: ""
+description: |-
+  
+---
+
+# stripe_webhook_endpoint
+
+## Example Usage
+
+```hcl
+resource "stripe_webhook_endpoint" "my_endpoint" {
+  url = "https://mydomain.example.com/webhook"
+
+  enabled_events = [
+    "charge.succeeded",
+    "charge.failed",
+    "source.chargeable",
+  ]
+}
+```
+
+## Schema
+
+### Required
+
+- **enabled_events** (List of String) The list of events to enable for this endpoint. `['*']` indicates that all events are enabled, except those that require explicit selection.
+- **url** (String) The URL of the webhook endpoint.
+
+### Optional
+
+- **connect** (Boolean)
+- **id** (String) The ID of this resource.
+
+### Read-Only
+
+- **secret** (String) The endpoint’s secret, used to generate webhook signatures. Only returned at creation.
+
+

--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -22,73 +22,87 @@ func resourceStripeCoupon() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"code": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true, // require it as the default one is more trouble than it's worth
+			"code": {
+				Type:        schema.TypeString,
+				Required:    true, // require it as the default one is more trouble than it's worth
+				Description: "The unique identifier of the coupon.",
 			},
-			"amount_off": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+			"amount_off": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Amount (in the `currency` specified) that will be taken off the subtotal of any invoices for this customer.",
 			},
-			"currency": &schema.Schema{
-				Type:     schema.TypeString, // <- check values
-				Optional: true,
-				ForceNew: true,
+			"currency": {
+				Type:        schema.TypeString, // <- check values
+				Optional:    true,
+				ForceNew:    true,
+				Description: "If `amount_off` has been set, the three-letter ISO code for the currency of the amount to take off.",
 			},
-			"duration": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true, // forever | once | repeating
-				ForceNew: true,
+			"duration": {
+				Type:        schema.TypeString,
+				Required:    true, // forever | once | repeating
+				ForceNew:    true,
+				Description: "One of `forever`, `once`, and `repeating`. Describes how long a customer who applies this coupon will get the discount.",
 			},
-			"duration_in_months": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+			"duration_in_months": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "If `duration` is `repeating`, the number of months the coupon applies. Null if coupon `duration` is `forever` or `once`.",
 			},
-			"max_redemptions": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  nil,
-				ForceNew: true,
+			"max_redemptions": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     nil,
+				ForceNew:    true,
+				Description: "Maximum number of times this coupon can be redeemed, in total, across all customers, before it is no longer valid.",
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
 			},
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the coupon displayed to customers on for instance invoices or receipts.",
 			},
-			"percent_off": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Optional: true,
-				ForceNew: true,
+			"percent_off": {
+				Type:        schema.TypeFloat,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $100 invoice $50 instead.",
 			},
-			"redeem_by": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"redeem_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Date after which the coupon can no longer be redeemed.",
 			},
 			// Computed
-			"valid": &schema.Schema{
-				Type:     schema.TypeBool,
-				Computed: true,
+			"valid": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Taking account of the above properties, whether this coupon can still be applied to a customer.",
 			},
-			"created": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
+			"created": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time at which the object was created. Measured in seconds since the Unix epoch.",
 			},
-			"livemode": &schema.Schema{
-				Type:     schema.TypeBool,
-				Computed: true,
+			"livemode": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
 			},
-			"times_redeemed": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
+			"times_redeemed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of times this coupon has been applied to a customer.",
 			},
 		},
 	}

--- a/stripe/resource_stripe_plan.go
+++ b/stripe/resource_stripe_plan.go
@@ -20,153 +20,177 @@ func resourceStripePlan() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"plan_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"plan_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for the plan.",
 			},
-			"active": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+			"active": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the plan can be used for new purchases.",
 			},
-			"amount": &schema.Schema{
+			"amount": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"amount_decimal"},
+				Description:   "The unit amount in cents to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`.",
 			},
-			"amount_decimal": &schema.Schema{
+			"amount_decimal": {
 				Type:          schema.TypeFloat,
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"amount"},
+				Description:   "The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`.",
 			},
-			"currency": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"currency": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Three-letter ISO currency code, in lowercase. Must be a supported currency.",
 			},
-			"interval": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"interval": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.",
 			},
-			"product": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"product": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The product whose pricing this plan determines.",
 			},
-			"aggregate_usage": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"aggregate_usage": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.",
 			},
-			"billing_scheme": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "per_unit",
+			"billing_scheme": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "per_unit",
+				Description: "Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.",
 			},
-			"interval_count": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  1,
+			"interval_count": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     1,
+				Description: "The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.",
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
 			},
-			"nickname": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"nickname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A brief description of the plan, hidden from customers.",
 			},
-			"tier": &schema.Schema{
+			"tier": {
 				Type: schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"up_to": &schema.Schema{
+						"up_to": {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"tier.up_to_inf"},
+							Description:   "Up to and including to this quantity will be contained in the tier.",
 						},
-						"up_to_inf": &schema.Schema{
+						"up_to_inf": {
 							Type:          schema.TypeBool,
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"tier.up_to"},
 						},
-						"flat_amount": &schema.Schema{
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"flat_amount": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Price for the entire tier.",
 						},
-						"flat_amount_decimal": &schema.Schema{
-							Type:     schema.TypeFloat,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"flat_amount_decimal": {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.",
 						},
-						"unit_amount": &schema.Schema{
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"unit_amount": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Per unit price for units relevant to the tier.",
 						},
-						"unit_amount_decimal": &schema.Schema{
-							Type:     schema.TypeFloat,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"unit_amount_decimal": {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.",
 						},
 					},
 				},
-				Optional: true,
-				ForceNew: true,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.",
 			},
-			"tiers_mode": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"tiers_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.",
 			},
-			"transform_usage": &schema.Schema{
+			"transform_usage": {
 				Type: schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"divide_by": &schema.Schema{
-							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
+						"divide_by": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: "Divide usage by this number.",
 						},
-						"round": &schema.Schema{
+						"round": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{"down", "up"}, false),
+							Description:  "After division, either round the result `up` or `down`.",
 						},
 					},
 				},
-				MaxItems: 1,
-				Optional: true,
-				ForceNew: true,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`.",
 			},
-			"trial_period_days": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
+			"trial_period_days": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Default number of trial days when subscribing a customer to this plan using `trial_from_plan=true`.",
 			},
-			"usage_type": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "licensed",
+			"usage_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "licensed",
+				Description: "Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.",
 			},
 		},
 	}
@@ -334,7 +358,7 @@ func flattenPlanTransformUsage(in *stripe.PlanTransformUsage) []map[string]inter
 	}
 	out := make([]map[string]interface{}, n)
 
-	for i, _ := range out {
+	for i := range out {
 		out[i] = map[string]interface{}{
 			"divide_by": in.DivideBy,
 			"round":     in.Round,

--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -22,119 +22,138 @@ func resourceStripePrice() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"price_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"price_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for the price.",
 			},
-			"active": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+			"active": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the price can be used for new purchases.",
 			},
-			"currency": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"currency": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Three-letter ISO currency code, in lowercase. Must be a supported currency.",
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
 			},
-			"nickname": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"nickname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A brief description of the price, hidden from customers.",
 			},
-			"product": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"product": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the product this price is associated with.",
 			},
-			"recurring": &schema.Schema{
+			"recurring": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "The recurring components of a price such as `interval` and `usage_type`.",
 			},
-			"unit_amount": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+			"unit_amount": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The unit amount in cents to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`.",
 			},
-			"unit_amount_decimal": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+			"unit_amount_decimal": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`.",
 			},
-			"billing_scheme": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"billing_scheme": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in quantity (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.",
 			},
-			"created": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
+			"created": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time at which the object was created. Measured in seconds since the Unix epoch.",
 			},
-			"livemode": &schema.Schema{
-				Type:     schema.TypeBool,
-				Computed: true,
+			"livemode": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
 			},
-			"tier": &schema.Schema{
+			"tier": {
 				Type: schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"up_to": &schema.Schema{
+						"up_to": {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"tier.up_to_inf"},
+							Description:   "Up to and including to this quantity will be contained in the tier.",
 						},
-						"up_to_inf": &schema.Schema{
+						"up_to_inf": {
 							Type:          schema.TypeBool,
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"tier.up_to"},
 						},
-						"flat_amount": &schema.Schema{
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"flat_amount": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Price for the entire tier.",
 						},
-						"flat_amount_decimal": &schema.Schema{
-							Type:     schema.TypeFloat,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"flat_amount_decimal": {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.",
 						},
-						"unit_amount": &schema.Schema{
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"unit_amount": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Per unit price for units relevant to the tier.",
 						},
-						"unit_amount_decimal": &schema.Schema{
-							Type:     schema.TypeFloat,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+						"unit_amount_decimal": {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.",
 						},
 					},
 				},
-				Optional: true,
-				ForceNew: true,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.",
 			},
-			"tiers_mode": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"tiers_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.",
 			},
 		},
 	}

--- a/stripe/resource_stripe_product.go
+++ b/stripe/resource_stripe_product.go
@@ -24,44 +24,51 @@ func resourceStripeProduct() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"product_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"product_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for the product.",
 			},
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The product’s name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.",
 			},
-			"type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "",
 			},
-			"active": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+			"active": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the product is currently available for purchase. Defaults to `true`.",
 			},
-			"attributes": &schema.Schema{
+			"attributes": {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
 			},
-			"statement_descriptor": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"statement_descriptor": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Extra information about a product which will appear on your customer’s credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used.",
 			},
-			"unit_label": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"unit_label": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions.",
 			},
 		},
 	}

--- a/stripe/resource_stripe_tax_rate.go
+++ b/stripe/resource_stripe_tax_rate.go
@@ -20,44 +20,53 @@ func resourceStripeTaxRate() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"active": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: true,
+			"active": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Defaults to `true`. When set to `false`, this tax rate cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.",
 			},
-			"created": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
+			"created": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time at which the object was created. Measured in seconds since the Unix epoch.",
 			},
-			"description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers.",
 			},
-			"display_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"display_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The display name of the tax rates as it will appear to your customer on their receipt email, PDF, and the hosted invoice page.",
 			},
-			"inclusive": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: true,
+			"inclusive": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "This specifies if the tax rate is inclusive or exclusive.",
 			},
-			"jurisdiction": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"jurisdiction": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The jurisdiction for the tax rate. You can use this label field for tax reporting purposes. It also appears on your customer’s invoice.",
 			},
-			"livemode": &schema.Schema{
-				Type:     schema.TypeBool,
-				Computed: true,
+			"livemode": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:    true,
+				Description: "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
 			},
-			"percentage": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Required: true,
+			"percentage": {
+				Type:        schema.TypeFloat,
+				Required:    true,
+				Description: "This represents the tax rate percent out of 100.",
 			},
 		},
 	}

--- a/stripe/resource_stripe_webhook_endpoint.go
+++ b/stripe/resource_stripe_webhook_endpoint.go
@@ -19,23 +19,26 @@ func resourceStripeWebhookEndpoint() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"url": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The URL of the webhook endpoint.",
 			},
-			"enabled_events": &schema.Schema{
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
+			"enabled_events": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				Description: "The list of events to enable for this endpoint. `['*']` indicates that all events are enabled, except those that require explicit selection.",
 			},
-			"connect": &schema.Schema{
+			"connect": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 			},
-			"secret": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+			"secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The endpoint’s secret, used to generate webhook signatures. Only returned at creation.",
 			},
 		},
 	}


### PR DESCRIPTION
My goal was to add documentation to display it in Terraform Registry: https://registry.terraform.io/providers/franckverrot/stripe/latest/docs

Added `Description` for resources fields from https://stripe.com/docs/api
Generated documentation for Terraform Registry via `tfplugindocs`
Tuned generated docs a bit (added examples and import sections)

You may preview how documentation will look like here: https://registry.terraform.io/tools/doc-preview#schema